### PR TITLE
[rocket-chip] Not working when DefaultRV32Config

### DIFF
--- a/sanitytests/rocketchip/src/VerilatorTest.scala
+++ b/sanitytests/rocketchip/src/VerilatorTest.scala
@@ -16,7 +16,7 @@ object VerilatorTest extends TestSuite {
   val tests = Tests {
     test("build TestHarness emulator") {
       val testHarness = classOf[freechips.rocketchip.system.TestHarness]
-      val configs = Seq(classOf[TestConfig], classOf[freechips.rocketchip.system.DefaultConfig])
+      val configs = Seq(classOf[TestConfig], classOf[freechips.rocketchip.system.DefaultRV32Config])
       val emulator = TestHarness(testHarness, configs, Some(outputDirectory)).emulator
       test("build hello") {
         os.proc(


### PR DESCRIPTION
This commit is a MWE of rocket not compiling when using DefaultRV32Config

It would complain

```
  java.lang.IllegalArgumentException: requirement failed: rowBits(64) != cacheDataBits(32)
    scala.Predef$.require(Predef.scala:281)
    freechips.rocketchip.rocket.HasL1HellaCacheParameters.$init$(HellaCache.scala:90)
    freechips.rocketchip.rocket.HellaCacheModule.<init>(HellaCache.scala:229)
    freechips.rocketchip.rocket.DCacheModule.<init>(DCache.scala:95)
```

Interestingly, it will work in `rocket-chip/vsim` (rocket chip master, no patch applied)

```
make verilog CONFIG=freechips.rocketchip.system.DefaultRV32Config
```

Seem to be a problem of rocket together with other newer components (e.g. chisel?)

Also note that there is a patch in playground https://github.com/sequencer/playground/blob/master/patches/rocket-chip/2968.patch