### PR TITLE
fix: Override dtm's default endianness to le

### DIFF
--- a/sanitytests/rocketchip/resources/csrc/SimDTM.cc
+++ b/sanitytests/rocketchip/resources/csrc/SimDTM.cc
@@ -3,8 +3,23 @@
 #include <fesvr/dtm.h>
 #include <vpi_user.h>
 #include <svdpi.h>
+#include "SimDTM.h"
 
-dtm_t* dtm;
+ledtm_t::ledtm_t(int argc, char** argv)
+  : dtm_t(argc, argv)
+{
+}
+
+ledtm_t::~ledtm_t()
+{
+}
+
+memif_endianness_t ledtm_t::get_target_endianness() const
+{
+  return memif_endianness_little;
+}
+
+ledtm_t* dtm;
 
 extern "C" int debug_tick
 (
@@ -23,7 +38,7 @@ extern "C" int debug_tick
     s_vpi_vlog_info info;
     if (!vpi_get_vlog_info(&info))
       abort();
-      dtm = new dtm_t(info.argc, info.argv);
+      dtm = new ledtm_t(info.argc, info.argv);
   }
 
   dtm_t::resp resp_bits;

--- a/sanitytests/rocketchip/resources/csrc/SimDTM.h
+++ b/sanitytests/rocketchip/resources/csrc/SimDTM.h
@@ -1,0 +1,9 @@
+#include <fesvr/dtm.h>
+
+class ledtm_t : public dtm_t
+{
+  public:
+    ledtm_t(int argc, char**argv);
+    ~ledtm_t();
+    memif_endianness_t get_target_endianness() const;
+};

--- a/sanitytests/rocketchip/resources/csrc/emulator.cc
+++ b/sanitytests/rocketchip/resources/csrc/emulator.cc
@@ -8,6 +8,7 @@
 #endif
 #include <fesvr/dtm.h>
 #include "remote_bitbang.h"
+#include "SimDTM.h"
 #include <iostream>
 #include <fcntl.h>
 #include <signal.h>
@@ -31,7 +32,7 @@
 //   variables:
 //     - static const char * verilog_plusargs
 
-extern dtm_t* dtm;
+extern ledtm_t* dtm;
 extern remote_bitbang_t * jtag;
 
 static uint64_t trace_count = 0;
@@ -267,7 +268,7 @@ done_processing:
 #endif
 
   jtag = new remote_bitbang_t(rbb_port);
-  dtm = new dtm_t(htif_argc, htif_argv);
+  dtm = new ledtm_t(htif_argc, htif_argv);
 
   signal(SIGTERM, handle_sigterm);
 


### PR DESCRIPTION
The default endianness of `dtm` has been changed from `little endian` to `undecided` since https://github.com/riscv-software-src/riscv-isa-sim/commit/f82e54124345f348abaa80ec82d67528a9a8f774, which breaks the [CI](https://github.com/chipsalliance/playground/runs/7710418003?check_suite_focus=true). 

Without interfering upstream, we need to override dtm's endian to little endian.