### PR TITLE
fix: Recover unmerged patch https://github.com/chipsalliance/rocket-chip/pull/3013

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ This repository always tracks remote developing branches, it may need some patch
 chipyard https://github.com/ucb-bar/chipyard/pull/1160  
 dsptools https://github.com/ucb-bar/dsptools/pull/240  
 rocket-chip https://github.com/chipsalliance/rocket-chip/pull/2968      
+rocket-chip https://github.com/chipsalliance/rocket-chip/pull/3013      
 rocket-chip-blocks https://github.com/chipsalliance/rocket-chip-blocks/pull/2  
 rocket-chip-fpga-shells https://github.com/chipsalliance/rocket-chip-fpga-shells/pull/1  
 rocket-chip-fpga-shells https://github.com/chipsalliance/rocket-chip-fpga-shells/pull/2  


### PR DESCRIPTION
Latest commit https://github.com/chipsalliance/playground/commit/b594d66ecffb7c8e3ceb766c5c392a71b9d9c9aa breaks the CI (RC cannot find package `chipsalliance` https://github.com/chipsalliance/playground/runs/8148735163?check_suite_focus=true#step:10:6173).

The close of https://github.com/chipsalliance/rocket-chip/pull/3013 leads to this. The simple solution would be temporally restore this patch before https://github.com/chipsalliance/rocket-chip/pull/3013 is properly handled.