### PR TITLE
Remove deprecated DSP

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -278,31 +278,13 @@ object barstools extends CommonModule with SbtModule { bt =>
   override def moduleDeps = super.moduleDeps ++ Seq(macros, iocell, tapeout)
 }
 
-object dsptools extends CommonModule with SbtModule { dt =>
-  override def millSourcePath = os.pwd / "dependencies" / "dsptools"
-
-  override def ivyDeps = Agg(
-    ivys.spire,
-    ivys.breeze
-  )
-}
-
-object rocketdsputils extends CommonModule with SbtModule {
-  // TODO: FIX
-  override def scalacOptions = T {
-    super.scalacOptions() ++ Agg("-Xsource:2.11")
-  }
-  override def millSourcePath = os.pwd / "dependencies" / "rocket-dsp-utils"
-  override def moduleDeps = super.moduleDeps ++ Seq(myrocketchip, dsptools)
-}
-
 object FFTGenerator extends CommonModule with SbtModule {
   // TODO: FIX
   override def scalacOptions = T {
     super.scalacOptions() ++ Agg("-Xsource:2.11")
   }
   override def millSourcePath = os.pwd / "dependencies" / "FFTGenerator"
-  override def moduleDeps = super.moduleDeps ++ Seq(myrocketchip, dsptools, rocketdsputils)
+  override def moduleDeps = super.moduleDeps ++ Seq(myrocketchip)
 }
 
 object gemmini extends CommonModule with SbtModule {
@@ -393,7 +375,7 @@ object chipyard extends CommonModule with SbtModule { cy =>
   }
   def basePath = os.pwd / "dependencies" / "chipyard"
   override def millSourcePath = basePath / "generators" / "chipyard"
-  override def moduleDeps = super.moduleDeps ++ Seq(myrocketchip, barstools, testchipip, blocks, icenet, boom, dsptools, rocketdsputils, gemmini, nvdla, hwacha, cva6, tracegen, sodor, sha3, ibex, FFTGenerator, constellation, mempress)
+  override def moduleDeps = super.moduleDeps ++ Seq(myrocketchip, barstools, testchipip, blocks, icenet, boom, gemmini, nvdla, hwacha, cva6, tracegen, sodor, sha3, ibex, FFTGenerator, constellation, mempress)
 
   object tracegen extends CommonModule with SbtModule {
     // TODO: FIX


### PR DESCRIPTION
- remove mac suppoort and fix a build system bug which may break idea
- fix for rc 213 breaking change
- Auto Bump
- Auto Bump
- Auto Bump
- Auto Bump
- Auto Bump
- Auto Bump
- fix: chisel3 pr #2758
- remove submodule: dsptools and rocket-dsp-utils
- remove submodule: FFTGenerator
- docs: update chipyard patch #1296
- fix: add constellation patch + remove EnhancedChisel3Assign in rocket-chip;
- update patches
- env: update patches
- env: update patches
- fix: using std 17 to use std::optional
- Rename memif_endianness_t to endianness_t
- Auto Bump
- Auto Bump
- Auto Bump
- Auto Bump
- remove dsp
